### PR TITLE
Replaced references from Gemcutter to RubyGems

### DIFF
--- a/engines/for_them/Gemfile
+++ b/engines/for_them/Gemfile
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source :rubygems
 
 if RUBY_VERSION < '1.9'
   gem "ruby-debug", ">= 0.10.3"

--- a/extending-active-record/by_star/Gemfile
+++ b/extending-active-record/by_star/Gemfile
@@ -1,4 +1,4 @@
-source :gemcutter
+source :rubygems
 
 # Specify your gem's dependencies in by_star.gemspec
 gemspec

--- a/gem-development/foodie/Gemfile
+++ b/gem-development/foodie/Gemfile
@@ -1,4 +1,4 @@
-source :gemcutter
+source :rubygems
 
 # Specify your gem's dependencies in gem_name.gemspec
 gemspec

--- a/gem-scaffold/foodie/Gemfile
+++ b/gem-scaffold/foodie/Gemfile
@@ -1,4 +1,4 @@
-source :gemcutter
+source :rubygems
 
 # Specify your gem's dependencies in foodie.gemspec
 gemspec


### PR DESCRIPTION
Although the gemcutter source lines still work, it's probably best to just use the rubygems ones instead to save confusing anyone out there who wouldn't know what gemcutter was.
