### PR TITLE
Fix filename. Error with markdown syntax.

### DIFF
--- a/gem-development.md
+++ b/gem-development.md
@@ -142,7 +142,7 @@ However, relying on a version simply greater than the latest-at-the-time is a su
 s.add_dependency "activesupport", "~> 4.0.0"
 ```
 
-When we run `bundle install` again, the `activesupport` gem will be installed for us to use. Of course, like the diligent TDD/BDD zealots we are, we will test our `pluralize` method before we code it. Let's add this test to _spec/food_spec.rb_ now inside our `describe Foodie::Food` block:
+When we run `bundle install` again, the `activesupport` gem will be installed for us to use. Of course, like the diligent TDD/BDD zealots we are, we will test our `pluralize` method before we code it. Let's add this test to *spec/food_spec.rb* now inside our `describe Foodie::Food` block:
 
 ```ruby
 it "pluralizes a word" do


### PR DESCRIPTION
The escaping for underscores isn't working for some reason so I switched for using underscores to asterisks for adding emphasis to filenames that include underscores.
