### PR TITLE
Use :post_id rather than :id in post route definition

### DIFF
--- a/ember.md
+++ b/ember.md
@@ -309,7 +309,7 @@ We can define this route in `app/assets/javascripts/router.js.coffee` by using t
 
 ```
 Blorgh.Router.map ()->
-  @resource 'post', path: '/posts/:id'
+  @resource 'post', path: '/posts/:post_id'
 ```
 
 The `resource` function defines a new route for our Ember app. When we refresh our app again, we will now be able to click on a post's link and go to that post's page. That doesn't currently display anything and the console again will tell us why:


### PR DESCRIPTION
You define the route for viewing an individual post like the following:

```
Blorgh.Router.map ()->
  @resource 'post', path: '/posts/:id'
```

This route is not incorrect in and of itself, but it won't automatically try to use the find method defined on the post model. For that to happen, it needs to be defined using `:post_id` rather than `:id`, like so:

```
Blorgh.Router.map ()->
  @resource 'post', path: '/posts/:post_id'
```

More info in the dynamic segments section of the ember routing guide at http://emberjs.com/guides/routing/defining-your-routes/

Otherwise, this is a really awesome guide :+1:  Great introduction to another JS framework for me.
