### PR TITLE
Fix typo of template file name in ember.md

### DIFF
--- a/ember.md
+++ b/ember.md
@@ -594,7 +594,7 @@ Now we've completed adding the `edit` and `update` functionality to our posts re
 <h2>{{title}}</h2>
 <div>
   {{#link-to 'posts.edit' this}}Edit{{/link-to}} |
-  <a {{action=destroy}}>Destroy</a>
+  <a {{action 'destroy' this}}>Destroy</a>
 </div>
 {{text}}
 ```
@@ -607,6 +607,7 @@ Blorgh.PostController = Ember.ObjectController.extend
     destroy: ->
       if confirm('Are you sure you want to delete this post?')
         this.content.destroy()
+        this.transitionTo('index')
 ```
 
 In the controller, we can reference the current model instance with `this.content` rather than `this.currentModel`. We first ask for confirmation of the deletion of this post and if it's confirmed then we call `destroy` on it which should trigger the destruction of this post.


### PR DESCRIPTION
- Template is `index.hbs`, not `index.js.coffee`.
- `DESTROY` part has a couple of minor issues.
